### PR TITLE
X11 Improvements

### DIFF
--- a/DrawFunctions.h
+++ b/DrawFunctions.h
@@ -34,6 +34,7 @@ void CNFGClearFrame();
 void CNFGSwapBuffers();
 
 void CNFGGetDimensions( short * x, short * y );
+void CNFGTearDown();
 void CNFGSetup( const char * WindowName, int w, int h );
 void CNFGSetupFullscreen( const char * WindowName, int screen_number );
 void CNFGHandleInput();

--- a/WinDriver.c
+++ b/WinDriver.c
@@ -123,10 +123,15 @@ LRESULT CALLBACK MyWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 	switch(msg)
 	{
 	case WM_DESTROY:
-		PostQuitMessage(0);
+		CNFGTearDown();
 		return 0;
 	}
 	return DefWindowProc(hwnd, msg, wParam, lParam);
+}
+
+void CNFGTearDown()
+{
+	PostQuitMessage(0);
 }
 
 //This was from the article, too... well, mostly.

--- a/XDriver.c
+++ b/XDriver.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 
 XWindowAttributes CNFGWinAtt;
+XClassHint *CNFGClassHint;
 Display *CNFGDisplay;
 Window CNFGWindow;
 Pixmap CNFGPixmap;
@@ -35,6 +36,20 @@ void CNFGGetDimensions( short * x, short * y )
 static void InternalLinkScreenAndGo( const char * WindowName )
 {
 	XGetWindowAttributes( CNFGDisplay, CNFGWindow, &CNFGWinAtt );
+
+	XGetClassHint( CNFGDisplay, CNFGWindow, CNFGClassHint );
+	if (!CNFGClassHint) {
+		CNFGClassHint = XAllocClassHint();
+		if (CNFGClassHint) {
+			CNFGClassHint->res_name = "cnping";
+			CNFGClassHint->res_class = "cnping";
+			XSetClassHint( CNFGDisplay, CNFGWindow, CNFGClassHint );
+		} else {
+			fprintf( stderr, "Failed to allocate XClassHint!\n" );
+		}
+	} else {
+		fprintf( stderr, "Pre-existing XClassHint\n" );
+	}
 
 	XSelectInput (CNFGDisplay, CNFGWindow, KeyPressMask | KeyReleaseMask | ButtonPressMask | ButtonReleaseMask | ExposureMask | PointerMotionMask );
 	XSetStandardProperties( CNFGDisplay, CNFGWindow, WindowName, WindowName, None, NULL, 0, NULL );


### PR DESCRIPTION
I added a few niceties in the X11 back-end.  
The first is to set the window hints. In particular GNOME uses the window class on it's integrated window menus, defaulting to just 'Unknown'.  
The second is to clean-up when the window is closed. Previously, after closing, I got errors of the form:

    XIO:  fatal IO error 11 (Resource temporarily unavailable) on X server ":0"
          after 13587 requests (13587 known processed) with 1 events remaining.

Now everything should be closed and freed up.