### PR TITLE
Issue #40

### DIFF
--- a/httping.c
+++ b/httping.c
@@ -33,7 +33,7 @@ void DoHTTPing( const char * addy, double minperiod, int * seqnoptr, volatile do
 {
 	struct sockaddr_in serveraddr;
 	struct hostent *server;
-	int httpsock;
+	int httpsock = 0;
 	int addylen = strlen(addy);
 	char hostname[addylen+1];
 	memcpy( hostname, addy, addylen + 1 );
@@ -56,13 +56,6 @@ void DoHTTPing( const char * addy, double minperiod, int * seqnoptr, volatile do
 			*eurl = 0;
 	}
 
-	*socketptr = httpsock = socket(AF_INET, SOCK_STREAM, 0);
-	if (httpsock < 0)
-	{
-		ERRM( "Error opening socket\n" );
-		return;
-	}
-
 	/* gethostbyname: get the server's DNS entry */
 	*getting_host_by_name = 1;
 	server = gethostbyname(hostname);
@@ -78,16 +71,26 @@ void DoHTTPing( const char * addy, double minperiod, int * seqnoptr, volatile do
 	memcpy((char *)&serveraddr.sin_addr.s_addr, (char *)server->h_addr, server->h_length);
 	serveraddr.sin_port = htons(portno);
 
-	/* connect: create a connection with the server */
-	if (connect(httpsock, (struct sockaddr*)&serveraddr, sizeof(serveraddr)) < 0) 
-	{
-		ERRM( "%s: ERROR connecting\n", hostname );
-		goto fail;
-	}
-
-
 	while( 1 )
 	{
+		if( !httpsock )
+		{
+			*socketptr = httpsock = socket(AF_INET, SOCK_STREAM, 0);
+			if (httpsock < 0)
+			{
+				ERRM( "Error opening socket\n" );
+				return;
+			}
+
+			/* connect: create a connection with the server */
+			if (connect(httpsock, (struct sockaddr*)&serveraddr, sizeof(serveraddr)) < 0) 
+			{
+				ERRM( "%s: ERROR connecting\n", hostname );
+				goto fail;
+			}
+		}
+
+
 		char buf[8192];
 
 		int n = sprintf( buf, "HEAD %s HTTP/1.1\r\nConnection: keep-alive\r\n\r\n", eurl?eurl:"/favicon.ico" );
@@ -98,8 +101,12 @@ void DoHTTPing( const char * addy, double minperiod, int * seqnoptr, volatile do
 		int breakout = 0;
 		while( !breakout )
 		{
-			n = read( httpsock, buf, sizeof(buf)-1 );
+			n = recv( httpsock, buf, sizeof(buf)-1, MSG_PEEK);
+			if( n > 0 ) n = read( httpsock, buf, sizeof(buf)-1);
+			else if( n == 0 ) break; //FIN received
+			
 			if( n < 0 ) return;
+			
 			int i;
 			for( i = 0; i < n; i++ )
 			{
@@ -109,11 +116,10 @@ void DoHTTPing( const char * addy, double minperiod, int * seqnoptr, volatile do
 				case 0: if( c == '\r' ) endstate++; break;
 				case 1: if( c == '\n' ) endstate++; else endstate = 0; break;
 				case 2: if( c == '\r' ) endstate++; else endstate = 0; break;
-				case 3: if( c == '\n' ) breakout = 1; else endstate = 0; break;
+				case 3: if( c == '\n' && i == n-1) breakout = 1; else endstate = 0; break;
 				}
 			}
 		}
-
 		*timeouttime = OGGetAbsoluteTime();
 
 		HTTPingCallbackGot( *seqnoptr );
@@ -123,8 +129,14 @@ void DoHTTPing( const char * addy, double minperiod, int * seqnoptr, volatile do
 			usleep( (int)(delay_time * 1000000) );
 		(*seqnoptr) ++;
 		HTTPingCallbackStart( *seqnoptr );
-
-
+		if( !breakout ) {
+#ifdef WIN32
+			closesocket( httpsock );
+#else
+			close( httpsock );
+#endif
+			*socketptr = httpsock = 0;
+		}
 	}
 fail:
 	return;


### PR DESCRIPTION
Hopefully the code speaks for itself. ~~The only problem I am aware of with the code is that MSG_PEEK may not work on windows. It works perfectly fine on linux to find out whether a TCP FIN packet has been received. However while coming up with this solution I found out that Microsoft advises against using MSG_PEEK https://support.microsoft.com/en-us/help/192599/info-avoid-data-peeking-in-winsock.~~
The HTTP server my Netgear router uses appears to be lighthttpd.
It closes the connection after a 401 response. The 401 response itself is not faulty. The fault lies with it sending a message body where it's not supposed to according to the HTPP RFC document. I don't know however if closing the connection after a 401 with a HEAD request is wrong.