### PR TITLE
Fix compile errors on macOS (MSG_NOSIGNAL)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ cnping.exe : cnping.c CNFGFunctions.c CNFGWinDriver.c os_generic.c ping.c httpin
 cnping : cnping.o CNFGFunctions.o CNFGXDriver.o os_generic.o ping.o httping.o
 	gcc $(CFLAGS) -o $@ $^ -lX11 -lm -lpthread $(LDFLAGS) 
 
-cnping_mac : cnping.c CNFGFunctions.c CNFGCocoaCGDriver.m os_generic.c ping.c
+cnping_mac : cnping.c CNFGFunctions.c CNFGCocoaCGDriver.m os_generic.c ping.c httping.o
 	gcc -o cnping $^ -x objective-c -framework Cocoa -framework QuartzCore -lm -lpthread
 
 searchnet : os_generic.o ping.o searchnet.o

--- a/httping.c
+++ b/httping.c
@@ -6,12 +6,12 @@
 #include <unistd.h>
 #include <sys/types.h>
 
+#ifndef MSG_NOSIGNAL
+	#define MSG_NOSIGNAL 0
+#endif
+
 #ifdef WIN32
 	#include <winsock2.h>
-	#ifndef MSG_NOSIGNAL 
-	#define MSG_NOSIGNAL 0
-	#endif
-
 #else
 	#include <sys/socket.h>
 	#include <netinet/in.h>
@@ -85,6 +85,11 @@ reconnect:
 		ERRMB( "%s: ERROR connecting\n", hostname );
 		goto fail;
 	}
+
+#ifdef __APPLE__
+	int opt = 1;
+	setsockopt(httpsock, SOL_SOCKET, SO_NOSIGPIPE, &opt, sizeof(opt));
+#endif
 
 	errbuffer[0] = 0;
 


### PR DESCRIPTION
Should the `#ifndef MSG_NOSIGNAL #define ...` code be in a `#ifdef __APPLE__` block? Are there other platforms on which `MSG_NOSIGNAL` could be undefined?

Fixes #46