### PR TITLE
Handle xdisplay null

### DIFF
--- a/CNFGXDriver.c
+++ b/CNFGXDriver.c
@@ -91,9 +91,8 @@ void CNFGSetupFullscreen( const char * WindowName, int screen_no )
 	int screen = XDefaultScreen(CNFGDisplay);
 	int xpos, ypos;
 
-	if (!XShapeQueryExtension(CNFGDisplay, &event_basep, &error_basep))
-	{
-    	fprintf( stderr, "X-Server does not support shape extension" );
+	if (!XShapeQueryExtension(CNFGDisplay, &event_basep, &error_basep)) {
+		fprintf( stderr, "X-Server does not support shape extension\n" );
 		exit( 1 );
 	}
 
@@ -164,6 +163,11 @@ void CNFGTearDown()
 void CNFGSetup( const char * WindowName, int w, int h )
 {
 	CNFGDisplay = XOpenDisplay(NULL);
+	if ( !CNFGDisplay ) {
+		fprintf( stderr, "Could not get an X Display.\n%s", 
+				 "Are you in text mode or using SSH without X11-Forwarding?\n" );
+		exit( 1 );
+	}
 	atexit( CNFGTearDown );
 	XGetWindowAttributes( CNFGDisplay, RootWindow(CNFGDisplay, 0), &CNFGWinAtt );
 

--- a/cnping.c
+++ b/cnping.c
@@ -36,9 +36,6 @@ uint64_t globalrx;
 uint64_t globallost;
 uint8_t pattern[8];
 
-int     runargc;
-char ** runargv;
-
 #define PINGCYCLEWIDTH 8192
 #define TIMEOUT 4
 
@@ -635,9 +632,6 @@ int main( int argc, const char ** argv )
 		argv = glargv;
 	}
 #endif
-
-	runargc = argc;
-	runargv = argv;
 
 	pingperiodseconds = 0.02;
 	ExtraPingSize = 0;


### PR DESCRIPTION
Prints a warning and grecefully exits instead of segmentaiton fault.
This can happen e.g. using SSH or in text mode.