### PR TITLE
Fix integer overflow during creation of random seed at startup

### DIFF
--- a/cnping.c
+++ b/cnping.c
@@ -616,7 +616,7 @@ int main( int argc, const char ** argv )
 	ShowWindow (GetConsoleWindow(), SW_HIDE);
 #endif
 
-	srand( (int)(OGGetAbsoluteTime()*100000) );
+	srand( (uintmax_t)(OGGetAbsoluteTime()*100000) );
 
 	for( i = 0; i < sizeof( pattern ); i++ )
 	{


### PR DESCRIPTION
The cast to int overflows and causes the srand() parameter to be basically the same each time the prgoram is run. This caused the "pattern" that is checked on receipt of a packet to be the same across invocations of cnping. This commit casts to an unsigned which srand expects anyway and makes sure we are able to hold the return value